### PR TITLE
Remove rm(Q) line from Takahashi_Davis

### DIFF
--- a/R/fns.R
+++ b/R/fns.R
@@ -39,7 +39,6 @@
 Takahashi_Davis <- function(Q,return_perm_chol = 0,cholQp = matrix(0,0,0),P=0,gc=0) {
 
     n <- nrow(Q)
-    rm(Q)
 
     if (dim(cholQp)[1] == 0) {
         symchol <- Cholesky(forceSymmetric(Q))


### PR DESCRIPTION
The line `rm(Q)` removes Q from the function environment, falling back on the global environment. So the function fails for calls like

```
library(Matrix)
library(sparseinv)
Q2 <- Diagonal(10)
Q2_inv <- Takahashi_Davis(Q2)
```